### PR TITLE
chor:replace deprecated  method

### DIFF
--- a/lib/screens/loginScreen.dart
+++ b/lib/screens/loginScreen.dart
@@ -53,7 +53,7 @@ class _LoginScreenState extends State<LoginScreen> {
               EdgeInsets.fromLTRB(deviceWidth * 0.05, 0, deviceWidth * 0.05, 0),
           child: NotificationListener<OverscrollIndicatorNotification>(
             onNotification: (OverscrollIndicatorNotification overscroll) {
-              overscroll.disallowGlow();
+              overscroll.disallowIndicator();
               return;
             },
             child: Form(

--- a/lib/screens/registerScreen.dart
+++ b/lib/screens/registerScreen.dart
@@ -58,7 +58,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
               EdgeInsets.fromLTRB(deviceWidth * 0.05, 0, deviceWidth * 0.05, 0),
           child: NotificationListener<OverscrollIndicatorNotification>(
             onNotification: (OverscrollIndicatorNotification overscroll) {
-              overscroll.disallowGlow();
+              overscroll.disallowIndicator();
               return;
             },
             child: Form(


### PR DESCRIPTION
Fix #53 
Replaces deprecated disallowGlow() with disallowIndicator()